### PR TITLE
Implemented language injections for strings.

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -37,6 +37,8 @@
                                implementationClass="in.twbs.pure.lang.PureParserDefinition"/>
         <lang.syntaxHighlighterFactory key="Purescript"
                                        implementationClass="in.twbs.pure.lang.highlight.PureSyntaxHighlighterFactory"/>
+        <lang.elementManipulator forClass="in.twbs.pure.lang.psi.cst.PureASTWrapperElement"
+                                 implementationClass="in.twbs.pure.lang.psi.cst.PureStringManipulator"/>
         <annotator language="Purescript" implementationClass="in.twbs.pure.lang.annotator.PureAnnotator"/>
         <!--<highlightVisitor id="Purescript" implementation="in.twbs.pure.lang.psi.PureHighlightVisitor"/>-->
     </extensions>

--- a/src/main/java/in/twbs/pure/lang/PureParserDefinition.java
+++ b/src/main/java/in/twbs/pure/lang/PureParserDefinition.java
@@ -1,6 +1,5 @@
 package in.twbs.pure.lang;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.ParserDefinition;
 import com.intellij.lang.PsiParser;
@@ -16,6 +15,7 @@ import in.twbs.pure.lang.file.PureFileStubType;
 import in.twbs.pure.lang.lexer.PureLexer;
 import in.twbs.pure.lang.parser.PureParser;
 import in.twbs.pure.lang.psi.PureTokens;
+import in.twbs.pure.lang.psi.cst.PureASTWrapperElement;
 import org.jetbrains.annotations.NotNull;
 
 public class PureParserDefinition implements ParserDefinition, PureTokens {
@@ -56,7 +56,7 @@ public class PureParserDefinition implements ParserDefinition, PureTokens {
     @NotNull
     @Override
     public PsiElement createElement(ASTNode node) {
-        return new ASTWrapperPsiElement(node);
+        return new PureASTWrapperElement(node);
     }
 
     @Override

--- a/src/main/java/in/twbs/pure/lang/psi/cst/PureASTWrapperElement.java
+++ b/src/main/java/in/twbs/pure/lang/psi/cst/PureASTWrapperElement.java
@@ -1,0 +1,56 @@
+package in.twbs.pure.lang.psi.cst;
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.impl.source.tree.LeafElement;
+import com.intellij.psi.tree.IElementType;
+import in.twbs.pure.lang.psi.PureElements;
+import org.jetbrains.annotations.NotNull;
+
+public class PureASTWrapperElement extends ASTWrapperPsiElement implements PsiLanguageInjectionHost {
+    public PureASTWrapperElement(ASTNode astNode) {
+        super(astNode);
+    }
+
+    public boolean isString() {
+        final IElementType type = getNode().getElementType();
+        return type.equals(PureElements.JSRaw) || type.equals(PureElements.StringLiteral);
+    }
+
+    public boolean isBlockString() {
+        return getStringText().startsWith("\"\"\"");
+    }
+
+    public boolean isMultilineString() {
+        return getStringText().indexOf('\n') != -1;
+    }
+
+    /**
+     * Returns the text of a string element, including its quotes.
+     */
+    @NotNull
+    public String getStringText() {
+        return isString() ? getNode().getFirstChildNode().getText() : "";
+    }
+
+    @Override
+    public boolean isValidHost() {
+        // Only supports block-strings or single-line strings.
+        return isString() && (isBlockString() || !isMultilineString());
+    }
+
+    @Override
+    public PureASTWrapperElement updateText(@NotNull String s) {
+        final ASTNode valueNode = getNode().getFirstChildNode();
+        assert valueNode instanceof LeafElement;
+        ((LeafElement)valueNode).replaceWithText(s);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public PureStringLiteralEscaper createLiteralTextEscaper() {
+        return new PureStringLiteralEscaper(this);
+    }
+}

--- a/src/main/java/in/twbs/pure/lang/psi/cst/PureStringLiteralEscaper.java
+++ b/src/main/java/in/twbs/pure/lang/psi/cst/PureStringLiteralEscaper.java
@@ -1,0 +1,10 @@
+package in.twbs.pure.lang.psi.cst;
+
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.impl.source.tree.injected.StringLiteralEscaper;
+
+public class PureStringLiteralEscaper extends StringLiteralEscaper<PsiLanguageInjectionHost> {
+    public PureStringLiteralEscaper(PsiLanguageInjectionHost host) {
+        super(host);
+    }
+}

--- a/src/main/java/in/twbs/pure/lang/psi/cst/PureStringManipulator.java
+++ b/src/main/java/in/twbs/pure/lang/psi/cst/PureStringManipulator.java
@@ -1,0 +1,42 @@
+package in.twbs.pure.lang.psi.cst;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.AbstractElementManipulator;
+import com.intellij.util.IncorrectOperationException;
+import com.jetbrains.licenseService.util.Pair;
+import org.jetbrains.annotations.NotNull;
+
+public class PureStringManipulator extends AbstractElementManipulator<PureASTWrapperElement> {
+    @Override
+    public PureASTWrapperElement handleContentChange(@NotNull PureASTWrapperElement psi, @NotNull TextRange range, String newContent) throws IncorrectOperationException {
+        final String oldText = psi.getText();
+        final String newText = oldText.substring(0, range.getStartOffset()) + newContent + oldText.substring(range.getEndOffset());
+        return psi.updateText(newText);
+    }
+
+    @NotNull
+    @Override
+    public TextRange getRangeInElement(@NotNull PureASTWrapperElement element) {
+        return pairToTextRange(element.isBlockString() ? getRangeForBlockString(element) : getRangeForString(element));
+    }
+
+    private static Pair<Integer, Integer> getRangeForBlockString(@NotNull PureASTWrapperElement element) {
+        final String text = element.getStringText();
+        final int start = text.indexOf("\"\"\"") + 3;
+        final int end = text.lastIndexOf("\"\"\"") - start;
+        return new Pair<Integer, Integer>(start, end);
+    }
+
+    private static Pair<Integer, Integer> getRangeForString(@NotNull PureASTWrapperElement element) {
+        final String text = element.getStringText();
+        final int start = text.indexOf("\"") + 1;
+        final int end = text.lastIndexOf("\"") - start;
+        return new Pair<Integer, Integer>(start, end);
+    }
+
+    private static TextRange pairToTextRange(Pair<Integer, Integer> pair) {
+        final int start = Math.max(pair.fst, 0);
+        final int end = Math.max(pair.snd, start);
+        return TextRange.from(start, end);
+    }
+}


### PR DESCRIPTION
This adds support for injecting languages into single-line strings and block strings.  For instance, we can inject JavaScript into a foreign import -

![image](https://cloud.githubusercontent.com/assets/3103764/5589810/2182014c-90ed-11e4-904c-f3acee7acf4f.png)

Note that escaped multiline strings are not supported.  For instance, the following does not support language injections -

```purescript
foo = "foo\
      \bar\
      \baz"
```